### PR TITLE
Color progress bar based on delay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: help
+help: ## Print help
+	@echo "Usage: make [target]"
+	@echo
+	@echo "Targets:"
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+
+.PHONY: test
+test: ## Run tests
+	@go test -v ./...

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Trains.
 
 ![Screenshot showing the iceportal-cli application](.github/screenshot-1.png)
 
+You can pick between one of two themes: `portal` and `delay`. The `portal` theme
+is the default one and looks like the screenshot above. The `delay` theme colors
+the progress bar according to the delay of the train: Green for no delay, red for
+a delay.
+
 You can get `iceportal-cli` by running: 
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v0.17.0
 	github.com/charmbracelet/lipgloss v0.4.0
 	github.com/jarcoal/httpmock v1.0.8
+	github.com/spf13/pflag v1.0.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
I found it hard to understand whether the train was on time or not, just by taking a quick glance at the program output. The red color would make me feel uneasy, as I generally associate it with warning signals; I constantly thought we're late, heh.

To mitigate that, I thought about making the progress bar green when the train is on time and red when it is not.
What do you think about that change?

<img width="680" alt="image" src="https://github.com/craftamap/iceportal-api/assets/175809/c88b3604-7142-4f11-868f-200ba5084e35">

<img width="793" alt="image" src="https://github.com/craftamap/iceportal-api/assets/175809/b3948205-48ca-47e0-8836-4c2b305726bd">


P.S. testing this live from a train. 😆 There are no tests for the view right now, but I could try to add one if needed.